### PR TITLE
Removed unnecessary cd command

### DIFF
--- a/build_thirdparty.sh
+++ b/build_thirdparty.sh
@@ -17,7 +17,6 @@ make -j
 
 
 cd ../../segment
-cd ThirdParty/segment
 rm segment
 make
 


### PR DESCRIPTION
After cd ../../segment, we don't have to cd into ThirdParty and hence the command is unnecessary.